### PR TITLE
gitignore xcode 4.2 xcuserdata folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.mode1v3
 *.pbxuser
+xcuserdata/


### PR DESCRIPTION
Hey guys,

We're using ObjQREncoder as a git submodule - thanks for the great code!

xcode 4.2 generates an xcuserdata folder which causes the git submodule to be marked as modified after building the project. Pretty annoying... This patch takes care of that.

Anyways - cheers!
Marcus
